### PR TITLE
Resend email verification after user update

### DIFF
--- a/stubs/UpdateUserProfileInformation.php
+++ b/stubs/UpdateUserProfileInformation.php
@@ -29,9 +29,21 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             ],
         ])->validateWithBag('updateProfileInformation');
 
-        $user->forceFill([
-            'name' => $input['name'],
-            'email' => $input['email'],
-        ])->save();
+        if ($input['email'] != $user->email & new User instanceof MustVerifyEmail) {
+            $user->forceFill([
+                'name' => $input['name'],
+                'email' => $input['email'],
+                // 'email_verified_at' => null, // If uncommented, this will force user to verify email before being able to navigate to any route requiring auth
+            ])->save();
+
+            $user->sendEmailVerificationNotification();
+        }
+
+        else {
+            $user->forceFill([
+                'name' => $input['name'],
+                'email' => $input['email'],
+            ])->save();
+        }
     }
 }


### PR DESCRIPTION
When Email Verification is used, send a verification request to the new email address when a user updates their email address.
Optional commented line will null the email_verified_at value, which will force the user to verify the new address before doing anything else while logged in.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
